### PR TITLE
Pin FWE version to v1.0.3

### DIFF
--- a/simulatedvehicle/ec2simulation/template.yaml
+++ b/simulatedvehicle/ec2simulation/template.yaml
@@ -24,7 +24,7 @@ Parameters:
   SourceRef:
     Description: Source Git branch, tag or commit ID (leave blank for HEAD)
     Type: String
-    Default: ""
+    Default: "v1.0.3"
   SourceUrlBatteryMonitoring:
     Description: Source Git clone URL for Battery Monitoring Sample repo (leave as default)
     Type: String
@@ -216,7 +216,7 @@ Resources:
           fi
           cd aws-iot-fleetwise-edge
           if [ '${SourceRef}' != '' ]; then
-            git checkout ${SourceRef}
+            sudo -u ubuntu git checkout ${SourceRef}
           fi
 
           # Install SocketCAN modules:
@@ -382,7 +382,7 @@ Resources:
           fi
           cd aws-iot-fleetwise-edge
           if [ '${SourceRef}' != '' ]; then
-            git checkout ${SourceRef}
+            sudo -u ubuntu git checkout ${SourceRef}
           fi
 
           # Install SocketCAN modules:


### PR DESCRIPTION
*Description of changes:* The project does not pin the version of the FleetWise edge agent, and it is no longer compatible with the HEAD of the main branch. This PR pins the version to the last version that supported Ubuntu 18.04, which is still used by this project.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
